### PR TITLE
Fix upload

### DIFF
--- a/lib/sftp_ex.ex
+++ b/lib/sftp_ex.ex
@@ -33,7 +33,7 @@ defmodule SftpEx do
     Returns :ok, or {:error, reason}
   """
   def upload(connection, remote_path, file_handle) do
-    TransferService.upload(connection.channel_pid, remote_path, file_handle)
+    TransferService.upload(connection, remote_path, file_handle)
   end
 
   @doc """


### PR DESCRIPTION
fix an issue with upload function where the wrong
connection is passed to TransferService.upload and
subsequent calls to the SFTP backend fail.
TransferService.upload should receive the entire
connection parameter, that is later on converted to
channel_pid in  SFTP.Service that calls the Erlang
ssh_ftp subsystem.
Other subsystem could be active and they should receive
the connection struct, not just the channel_pid.