### PR TITLE
Fix pattern match on successfull :ssh.start

### DIFF
--- a/lib/ssh/service.ex
+++ b/lib/ssh/service.ex
@@ -7,7 +7,7 @@ defmodule SSH.Service do
 
   def start do
       case  :ssh.start do
-       {:ok} -> Logger.info "Connected"
+       :ok -> Logger.info "Connected"
        e -> S.handle_error(e)
        end
   end


### PR DESCRIPTION
Hi, I changed the :ssh.start successfull pattern match to :ok, this way there are no error logs on a successfull connection. 

Thanks for creating this library :)