### PR TITLE
Fix removing directories

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
+%{
+  "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
-  "mock": {:hex, :mock, "0.2.0", "5991877be6bb514b647dbd6f4869bc12bd7f2829df16e86c98d6108f966d34d7", [:mix], [{:meck, "~> 0.8.2", [hex: :meck, optional: false]}]}}
+  "meck": {:hex, :meck, "0.8.12", "1f7b1a9f5d12c511848fec26bbefd09a21e1432eadb8982d9a8aceb9891a3cf2", [:rebar3], [], "hexpm"},
+  "mock": {:hex, :mock, "0.2.0", "5991877be6bb514b647dbd6f4869bc12bd7f2829df16e86c98d6108f966d34d7", [:mix], [{:meck, "~> 0.8.2", [hex: :meck, optional: false]}]},
+}

--- a/test/sftp/management_service_test.exs
+++ b/test/sftp/management_service_test.exs
@@ -13,11 +13,11 @@ defmodule SFTP.ManagementServiceTest do
   end
 
   test "remove directory" do
-    assert :ok == ManagementService.remove_directory(@test_connection, "test/testdir")
+    assert :ok == ManagementService.remove_directory(@test_connection, "test/data")
   end
 
   test "remove non-existent directory" do
-    assert {:error, "Error deleting directory"} ==
+    assert {:error, "No Such Path"} ==
              ManagementService.remove_directory(@test_connection, "baddir")
   end
 

--- a/test/sftp/service_mock.exs
+++ b/test/sftp/service_mock.exs
@@ -39,7 +39,7 @@ defmodule SFTP.ServiceMock do
   end
 
   def list_dir(_connection, _remote_path) do
-    {:ok, ["test/data/test_file.txt", "test/data/test_file.txt"]}
+    {:ok, ["test_file.txt"]}
   end
 
   def delete(_connection, file) do
@@ -51,7 +51,7 @@ defmodule SFTP.ServiceMock do
 
   def delete_directory(_connection, file) do
     cond do
-      file == "test/testdir" -> :ok
+      file == "test/data" -> :ok
       true -> {:error, "Error deleting directory"}
     end
   end


### PR DESCRIPTION
Removing directories with files inside doesn't work because:
1) Syntax in `remove_all_files/3` is incorrect, where `remove_file(connection, & &1)` is passed as a second argument to `Enum.map/2`
2) Relative path to file is passed to `remove_file/2` instead of absolute one.

Removing empty directories also doesn't work correctly, because `list_files/2` is returning an error for empty directories.

This PR fixes that and also fixes listing files - in the docs for `SftpEx.ls/2` it is stated that the function returns `{:ok, [Filename]}, or {:error, reason}` when actually it returned `[Filename]` or `{:error, reason}`
