### PR TITLE
Fix code blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ transfer files via SFTP.
 
 The following is an example of creating a connection with a username and password. 
 
-    {:ok, conn} = SftpEx.connect([host: 'somehost', user: 'someuser', password: 'somepassword'])
+```elixir
+{:ok, conn} = SftpEx.connect([host: 'somehost', user: 'someuser', password: 'somepassword'])
+```
 
 Other connection arguments can be found in the [Erlang documentation]("http://erlang.org/doc/man/ssh.html#connect-3") 
 
@@ -16,43 +18,53 @@ Other connection arguments can be found in the [Erlang documentation]("http://er
 
 An example of writing a file to a server is the following.
     
-    stream = File.stream!("filename.txt")
-        |> Stream.into(SftpEx.stream!(connection,"/home/path/filename.txt"))
-        |> Stream.run
+```elixir
+stream = 
+  File.stream!("filename.txt")
+  |> Stream.into(SftpEx.stream!(connection,"/home/path/filename.txt"))
+  |> Stream.run
+```
    
 A file can be downloaded as follows - in this example a remote file "test2.csv" is downloaded to 
 the local file "filename.txt" 
 
-    SftpEx.stream!(connection,"test2.csv") |> Stream.into(File.stream!("filename.txt")) |> Stream.run
+```elixir
+SftpEx.stream!(connection,"test2.csv") |> Stream.into(File.stream!("filename.txt")) |> Stream.run
+```
 
 or using Enum.into
 
-    SftpEx.stream!(connection, "test2.csv") |> Enum.into(File.stream!("filename.txt"))
+```elixir
+SftpEx.stream!(connection, "test2.csv") |> Enum.into(File.stream!("filename.txt"))
+```
     
 This follows the same pattern as Elixir IO streams so a file can be transferred
 from one server to another via SFTP as follows.
 
-    stream = SftpEx.stream!(connection,"/home/path/filename.txt")
-    |> Stream.into(SftpEx.stream!(connection2,"/home/path/filename.txt"))
-    |> Stream.run
+```elixir
+stream = 
+  SftpEx.stream!(connection,"/home/path/filename.txt")
+  |> Stream.into(SftpEx.stream!(connection2,"/home/path/filename.txt"))
+  |> Stream.run
+```
 
 ## Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
 
-  1. Add `sftp_ex` to your list of dependencies in `mix.exs`:
+1. Add `sftp_ex` to your list of dependencies in `mix.exs`:
 
-    ```elixir
-    def deps do
-      [{:sftp_ex, "~> 0.2.1"}]
-    end
-    ```
+```elixir
+def deps do
+  [{:sftp_ex, "~> 0.2.1"}]
+end
+```
 
-  2. Ensure `sftp_ex` is started before your application:
+2. Ensure `sftp_ex` is started before your application:
 
-    ```elixir
-    def application do
-      [applications: [:sftp_ex]]
-    end
-    ```
+```elixir
+def application do
+  [applications: [:sftp_ex]]
+end
+```
 


### PR DESCRIPTION
Hi I came across this project and noticed the formatting of the code samples in the README wasn't displaying correctly in GitHub.

This PR puts all the code at column zero and uses elixir code highlighting throughout.

I formatted the multi-line pipelines in the elixir 1.6 formatter style.